### PR TITLE
feat: added custom group and registered items in it

### DIFF
--- a/src/main/java/name/modid/ModItemGroup.java
+++ b/src/main/java/name/modid/ModItemGroup.java
@@ -1,0 +1,41 @@
+package name.modid;
+
+import net.fabricmc.fabric.api.itemgroup.v1.FabricItemGroup;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemGroup;
+import net.minecraft.item.ItemGroup.DisplayContext;
+import net.minecraft.item.ItemGroup.Entries;
+import net.minecraft.item.ItemStack;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.Registry;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.registry.RegistryKeys;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+
+public class ModItemGroup {
+    // Define the registry key for the custom item group
+    public static final RegistryKey<ItemGroup> CUSTOM_ITEM_GROUP_KEY = RegistryKey.of(RegistryKeys.ITEM_GROUP,
+            Identifier.of("polycraft", "custom_group"));
+
+    // Define the custom item group
+    public static final ItemGroup CUSTOM_ITEM_GROUP = Registry.register(
+            Registries.ITEM_GROUP,
+            CUSTOM_ITEM_GROUP_KEY,
+            FabricItemGroup.builder()
+                    .displayName(Text.translatable("polycraft"))
+                    .icon(() -> new ItemStack(ModItems.CUSTOM_ITEM))
+                    .entries(ModItemGroup::addItemsToGroup)
+                    .build());
+
+    // Method to add items to the custom group
+    public static void addItemsToGroup(DisplayContext context, Entries entries) {
+        for (Item item : ModItems.ITEMS) {
+            entries.add(item);
+        }
+    }
+
+    public static void initialize() {
+        System.out.println("Custom item group initialized");
+    }
+}

--- a/src/main/java/name/modid/ModItems.java
+++ b/src/main/java/name/modid/ModItems.java
@@ -1,41 +1,41 @@
 package name.modid;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents;
 import net.minecraft.item.Item;
 import net.minecraft.item.Items;
-import net.minecraft.item.ItemGroups;
-import net.minecraft.registry.Registries;
-import net.minecraft.registry.Registry;
 import net.minecraft.registry.RegistryKey;
 import net.minecraft.registry.RegistryKeys;
 import net.minecraft.util.Identifier;
-import net.fabricmc.api.ModInitializer;
-import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents;
-
-import java.util.function.Function;
-import java.util.List;
-import java.util.ArrayList;
 
 public class ModItems {
+    // This is a class that contains all of our items
     private ModItems() {
     }
+
+    // list to keep track of our items
     public static final List<Item> ITEMS = new ArrayList<>();
 
+    // create items
     public static final Item CUSTOM_ITEM = register("suspicious_substance", Item::new, new Item.Settings());
     public static final Item EOLIENNE = register("eolienne", Item::new, new Item.Settings());
- 
+
     public static Item register(String path, Function<Item.Settings, Item> factory, Item.Settings settings) {
         final RegistryKey<Item> registryKey = RegistryKey.of(RegistryKeys.ITEM, Identifier.of("polycraft", path));
-        
+
         Item item = Items.register(registryKey, factory, settings);
         ITEMS.add(item);
-        
+
         return item;
-      }
+    }
 
     public static void initialize() {
         // This is where you would normally initialize your items
         // but we will do that in the register method
-        ItemGroupEvents.modifyEntriesEvent(ItemGroups.INGREDIENTS).register(entries -> {
+        ItemGroupEvents.modifyEntriesEvent(ModItemGroup.CUSTOM_ITEM_GROUP_KEY).register(entries -> {
             for (Item item : ITEMS) {
                 entries.add(item);
             }


### PR DESCRIPTION
This pull request introduces a new custom item group and modifies the item registration process to include items in this new group. The most important changes include the creation of the `ModItemGroup` class, updates to the `ModItems` class, and adjustments to the item registration method.

### Custom Item Group Creation:

* [`src/main/java/name/modid/ModItemGroup.java`](diffhunk://#diff-4b2fb88d7f09ac243c9cb9eda40821d29537e811932c10671544c9c8cf6628fcR1-R41): Added a new class `ModItemGroup` to define and register a custom item group called `CUSTOM_ITEM_GROUP`. This includes methods for adding items to the group and initializing the group.

### Updates to Item Registration:

* [`src/main/java/name/modid/ModItems.java`](diffhunk://#diff-a964c2f4e3af828046f8e7f044c66bd9176f727a2a0b66ed77a01538e7ef7e10R3-R22): Updated the `ModItems` class to import necessary packages, define a list to keep track of items, and create items.
* [`src/main/java/name/modid/ModItems.java`](diffhunk://#diff-a964c2f4e3af828046f8e7f044c66bd9176f727a2a0b66ed77a01538e7ef7e10L38-R38): Modified the `initialize` method to register items to the new custom item group instead of the default `ItemGroups.INGREDIENTS`.